### PR TITLE
Fixes for macos build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,14 @@ cmake_minimum_required(VERSION 3.12)
 project(sdl_event_forwarder CXX)
 set(CMAKE_CXX_STANDARD 17)
 
-find_package(SDL2 REQUIRED)
+INCLUDE(cmake/FindSDL2.cmake)
 
 add_executable(sdl_event_forwarder
 	main.cpp
 )
 
-set(SDL2_INCLUDE_DIR /usr/local/include)
+
+message("-- SDL2 include dir =  ${SDL2_INCLUDE_DIR} ")
 
 target_include_directories(sdl_event_forwarder PRIVATE
 		${SDL2_INCLUDE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(sdl_event_forwarder
 	main.cpp
 )
 
+set(SDL2_INCLUDE_DIR /usr/local/include)
+
 target_include_directories(sdl_event_forwarder PRIVATE
 		${SDL2_INCLUDE_DIR}
 )

--- a/cmake/FindSDL2.cmake
+++ b/cmake/FindSDL2.cmake
@@ -82,7 +82,18 @@ find_package_handle_standard_args(SDL2
     VERSION_VAR SDL2_VERSION
 )
 
+
 if(SDL2_FOUND)
+
+    # Trim SDL2 from the end of the include path if its there. 
+    # This allows #include "SDL2/sdl.h" in main.cpp to work. 
+    get_filename_component(last_dir "${SDL2_INCLUDE_DIR}" NAME)    
+    if ("${last_dir}" MATCHES "SDL2")
+        get_filename_component(trim_dir "${SDL2_INCLUDE_DIR}" PATH)    
+        set(SDL2_INCLUDE_DIR "${trim_dir}")
+    endif()
+
+
     # SDL2 imported target.
     add_library(SDL2::SDL2 UNKNOWN IMPORTED)
     set_target_properties(SDL2::SDL2 PROPERTIES

--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <termios.h>
+#include <algorithm>
 
 int set_interface_attribs(int fd, int speed) {
     struct termios tty;


### PR DESCRIPTION
Getting STL build errors due to functions not found, adding **#include algorithm** to fix this. 

Also SDL2 include files were not found on MacOS, 2 issues

1) CMakeLists.txt was not including FindSDL2.cmake, so added. 
2) Appears include path contains 'SDL2' folder at the end so removed this when detected

cmake .. works  
make works